### PR TITLE
Fast fix for servers where the arp utility is not installed.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,6 +88,10 @@ _install()
             wget https://raw.githubusercontent.com/FastVPSEestiOu/debian_netconsole/master/netconsole.sh -O /usr/local/bin/netconsole --no-check-certificate -q 
             _echo_result $?
             
+            echo -ne "Installing net-tools .. "
+            apt-get update -qq && apt-get install -qq net-tools > /dev/null
+            _echo_result $?
+            
             echo -ne "Performing chmod... "
             chmod +x /usr/local/bin/netconsole
             _echo_result $?
@@ -119,6 +123,9 @@ _install()
             chmod +x /etc/init.d/netconsole
             _echo_result $?
             
+            echo -ne "Installing net-tools .. "
+            apt-get update -qq && apt-get install -qq net-tools > /dev/null
+            _echo_result $?
             
             echo -ne "Starting netconsole... "
             /etc/init.d/netconsole start > /dev/null


### PR DESCRIPTION
Example output of the issue:

OS: Debian9
Testing ping utility... OK
Downloading config... OK
Downloading systemd service... OK
Downloading stop-start script... OK
Performing chmod... OK
Performing daemon-reload... OK
Starting netconsole... Job for netconsole.service failed because the control process exited with error code.
See "systemctl status netconsole.service" and "journalctl -xe" for details.
FAIL

systemctl status netconsole.service
● netconsole.service - netconsole logging faciity
   Loaded: loaded (/etc/systemd/system/netconsole.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Wed 2018-01-10 18:42:16 MSK; 6s ago
  Process: 6435 ExecStop=/usr/local/bin/netconsole stop (code=exited, status=0/SUCCESS)
  Process: 6441 ExecStart=/usr/local/bin/netconsole start (code=exited, status=1/FAILURE)
 Main PID: 6441 (code=exited, status=1/FAILURE)

янв 10 18:42:16 s052d7f06.fastvps-server.com systemd[1]: Starting netconsole logging faciity...
янв 10 18:42:16 s052d7f06.fastvps-server.com netconsole[6441]: /usr/local/bin/netconsole: line 34: arp: command not fo
янв 10 18:42:16 s052d7f06.fastvps-server.com netconsole[6441]: /usr/local/bin/netconsole: line 46: arp: command not fo
янв 10 18:42:16 s052d7f06.fastvps-server.com netconsole[6441]: We can't get GATEWAY_MAC and no DESTINATION_SERVER_MAC
янв 10 18:42:16 s052d7f06.fastvps-server.com systemd[1]: netconsole.service: Main process exited, code=exited, status=
янв 10 18:42:16 s052d7f06.fastvps-server.com systemd[1]: Failed to start netconsole logging faciity.
янв 10 18:42:16 s052d7f06.fastvps-server.com systemd[1]: netconsole.service: Unit entered failed state.
янв 10 18:42:16 s052d7f06.fastvps-server.com systemd[1]: netconsole.service: Failed with result 'exit-code'.