### PR TITLE
Fix for systemd unit

### DIFF
--- a/netconsole.service
+++ b/netconsole.service
@@ -1,8 +1,7 @@
 # /etc/systemd/system/netconsole.service
 [Unit]
 Description=netconsole logging faciity
-After=networking.service
-Requires=networking.service
+After=network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
There is no networking.service in some modern environments.
It is also better to use systemd built-in target.