### PR TITLE
Fixed installation of the netconsole-service package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,9 +165,11 @@ _install()
             exit 0
         ;;
         CentOS[5-8] )
-            echo -ne "Installing netconsole-service .. "
-            yum install -q -y netconsole-service > /dev/null
-            _echo_result $?
+            if yum list available netconsole-service > /dev/null; then
+                echo -ne "Installing netconsole-service... "
+                yum install -q -y netconsole-service > /dev/null
+                _echo_result $?
+            fi
 
             echo -ne "Setting remote server IP..."
             sed -i -e '/^SYSLOGADDR=/d' -e 's|\(# SYSLOGADDR=.*$\)|# SYSLOGADDR=\nSYSLOGADDR=148.251.39.245|g' /etc/sysconfig/netconsole


### PR DESCRIPTION
This package is for CentOS 8 only, and installing it on other operating systems will result in an error.